### PR TITLE
mise à jour pour version 1.5.8 (beta)

### DIFF
--- a/DynaCulture/Data/DynaCultureBehavior.cs
+++ b/DynaCulture/Data/DynaCultureBehavior.cs
@@ -34,7 +34,7 @@ namespace DynaCulture.Data
             CampaignEvents.OnSettlementOwnerChangedEvent.AddNonSerializedListener((object)this, new Action<Settlement, bool, Hero, Hero, Hero, ChangeOwnerOfSettlementAction.ChangeOwnerOfSettlementDetail>(this.OnSettlementOwnerChangedMod));
             CampaignEvents.ClanChangedKingdom.AddNonSerializedListener((object)this, new Action<Clan, Kingdom, Kingdom, bool, bool>(this.OnClanChangedKingdomMod));
             CampaignEvents.OnBeforeSaveEvent.AddNonSerializedListener((object)this, new Action(this.OnSave));
-            CampaignEvents.HourlyTickPartyEvent.AddNonSerializedListener((object)this, new Action<MobileParty>(this.RemoveCorruptedTroops));
+            //CampaignEvents.HourlyTickPartyEvent.AddNonSerializedListener((object)this, new Action<MobileParty>(this.RemoveCorruptedTroops));
 
             //if (System.Diagnostics.Debugger.IsAttached)
             //CampaignEvents.SettlementEntered.AddNonSerializedListener((object)this, new Action<MobileParty, Settlement, Hero>(this.DebugCulture));
@@ -119,7 +119,7 @@ namespace DynaCulture.Data
                     DynaCultureManager.Instance.InfluenceMap[settlement.StringId].OnNewOwner();
             }
         }
-
+        /*
         public void RemoveCorruptedTroops(MobileParty mobileParty)
         {
             // search for corrupted troops
@@ -136,7 +136,7 @@ namespace DynaCulture.Data
                     InformationManager.DisplayMessage(new InformationMessage(new TextObject($"Corrupted troops were removed from {mobileParty.Name} party.", (Dictionary<string, TextObject>)null).ToString(), Colors.Yellow));
             }
         }
-
+        */
         //public void DebugCulture(MobileParty party, Settlement settlement, Hero hero)
         //{
         //    try


### PR DESCRIPTION
Modlib is no longer updated.
A fork of modlib is still being update (Mod Configuration Menu https://www.nexusmods.com/mountandblade2bannerlord/mods/612?tab=description)
The is a need to make Mod Configuration Menu a dependency
This mod itself (MCM) have multiple dependencies:
butterlib(https://www.nexusmods.com/mountandblade2bannerlord/mods/2018)
Harmony (https://www.nexusmods.com/mountandblade2bannerlord/mods/2006)
UIExtenderEX(https://www.nexusmods.com/mountandblade2bannerlord/mods/2102)
Concerning corrupted troops mobileParty.MemberRoster.Troops no longer exist
I started a new game to see if there is still corrupted troops after some time
(users have to be aware of it since there is no longer the possibility to remove corrupted troops IMO)
The corrupted troop where in mobileParty.MemberRoster.data (which is private) and the new function mobileParty.MemberRoster.GetTroopRoster() doesn't return corrupted troops
Let's hope this probleme is fixed