### PR TITLE
update for 1.5.7

### DIFF
--- a/DynaCulture/Data/DynaCultureBehavior.cs
+++ b/DynaCulture/Data/DynaCultureBehavior.cs
@@ -34,7 +34,7 @@ namespace DynaCulture.Data
             CampaignEvents.OnSettlementOwnerChangedEvent.AddNonSerializedListener((object)this, new Action<Settlement, bool, Hero, Hero, Hero, ChangeOwnerOfSettlementAction.ChangeOwnerOfSettlementDetail>(this.OnSettlementOwnerChangedMod));
             CampaignEvents.ClanChangedKingdom.AddNonSerializedListener((object)this, new Action<Clan, Kingdom, Kingdom, bool, bool>(this.OnClanChangedKingdomMod));
             CampaignEvents.OnBeforeSaveEvent.AddNonSerializedListener((object)this, new Action(this.OnSave));
-            //CampaignEvents.HourlyTickPartyEvent.AddNonSerializedListener((object)this, new Action<MobileParty>(this.RemoveCorruptedTroops));
+            CampaignEvents.HourlyTickPartyEvent.AddNonSerializedListener((object)this, new Action<MobileParty>(this.RemoveCorruptedTroops));
 
             //if (System.Diagnostics.Debugger.IsAttached)
             //CampaignEvents.SettlementEntered.AddNonSerializedListener((object)this, new Action<MobileParty, Settlement, Hero>(this.DebugCulture));
@@ -119,13 +119,13 @@ namespace DynaCulture.Data
                     DynaCultureManager.Instance.InfluenceMap[settlement.StringId].OnNewOwner();
             }
         }
-        /*
+        
         public void RemoveCorruptedTroops(MobileParty mobileParty)
         {
             // search for corrupted troops
             IEnumerable<CharacterObject> characterObjects = mobileParty.MemberRoster.Troops.Where(c => c.Age == 0f);
-
-            if(characterObjects.Any())
+            
+            if (characterObjects.Any())
             {
                 // delete them
                 foreach (CharacterObject troop in characterObjects)
@@ -133,10 +133,10 @@ namespace DynaCulture.Data
 
                 // report to user
                 if (Settings.Instance.ShowCorruptedTroopMessage)
-                    InformationManager.DisplayMessage(new InformationMessage(new TextObject($"Corrupted troops were removed from {mobileParty.Name} party.", (Dictionary<string, TextObject>)null).ToString(), Colors.Yellow));
+                    InformationManager.DisplayMessage(new InformationMessage(new TextObject($"Corrupted troops were removed from {mobileParty.Name} party.", (Dictionary<string, object>)null).ToString(), Colors.Yellow));
             }
         }
-        */
+        
         //public void DebugCulture(MobileParty party, Settlement settlement, Hero hero)
         //{
         //    try


### PR DESCRIPTION
I encounter a engine crash on 1.5.8 We should wait for it to be stable...
Corrupted troop isn't obsolete in 1.5.7 but we still have to use MCM since modLib is not longer updated