### PR TITLE
Remove hardcoded directory paths

### DIFF
--- a/DynaCulture/ChangeCultureBehavior.cs
+++ b/DynaCulture/ChangeCultureBehavior.cs
@@ -197,8 +197,8 @@ namespace ChangeSettlementCulture.Data
                     }
                     msg2 += "\n";
                 }
-                string file = $@"C:\Users\{Environment.UserName}\Desktop\debug.txt";
-                string file2 = $@"C:\Users\{Environment.UserName}\Desktop\debugPrevious.txt";
+                string file = $@"{Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory)}\debug.txt";
+                string file2 = $@"{Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory)}\debugPrevious.txt";
                 if (System.IO.File.Exists(file))
                 {
                     if (System.IO.File.Exists(file2))

--- a/DynaCulture/Util/FileUtil.cs
+++ b/DynaCulture/Util/FileUtil.cs
@@ -42,7 +42,7 @@ namespace DynaCulture.Util
 
         public static string GetConfigDirectory()
         {
-            return $@"C:\Users\{Environment.UserName}\Documents\Mount and Blade II Bannerlord\Configs\DynaCulture\";
+            return $@"{Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)}\Mount and Blade II Bannerlord\Configs\DynaCulture\";
         }
 
         public static string GetSerializedFileName(string characterName)


### PR DESCRIPTION
Due to some weirdness with how I installed Windows, it was not installed to the C drive. As a result, these hardcoded paths cause my game to crash as soon as I load into the map because the directory cannot be found. Fortunately, .NET has an easy way to get these paths dynamically, which works perfectly.